### PR TITLE
Updated URLs to be permanent, to avoid issues if repo gets moved again.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * [Status](#status)
 
 ## General info
-The Pedigree subgroup in the GA4GH Clinical and Phenotypic Data Capture Work Stream has developed an initial draft of the standard that contains a [conceptual model](https://github.com/ga4gh-cp/pedigree/blob/2021-01/model.md) and a [minimal dataset document](https://docs.google.com/document/d/1UAtSLBEQ_7ePRLvDPRpoFpiXnl6VQEJXL2eQByEmfGY/edit). This project is an implementation of the conceptual model in FHIR. The generated documentation can be accessed [here](https://ga4gh-cp.github.io/pedigree-fhir-ig/).
+The Pedigree subgroup in the GA4GH Clinical and Phenotypic Data Capture Work Stream has developed an initial draft of the standard that contains a [conceptual model](https://github.com/GA4GH-Pedigree-Standard/pedigree/blob/master/model.md) and a [minimal dataset document](https://docs.google.com/document/d/1UAtSLBEQ_7ePRLvDPRpoFpiXnl6VQEJXL2eQByEmfGY/edit). This project is an implementation of the conceptual model in FHIR. The generated documentation can be accessed [here](http://purl.org/ga4gh/pedigree-fhir-ig/index.html).
 
 ## Technologies
 * [FHIR Shorthand](http://hl7.org/fhir/uv/shorthand/)

--- a/input/fsh/Alias.fsh
+++ b/input/fsh/Alias.fsh
@@ -21,5 +21,6 @@ Alias: $UBERON = http://purl.obolibrary.org/obo/uberon.owl
 /**
  Local aliases
  */
-Alias: $PedigreeRelationships = http://ga4gh-cp.github.io/pedigree-fhir-ig/CodeSystem/PedigreeRelationships
-Alias: $PedigreeRelationshipsCodeSystem = http://ga4gh-cp.github.io/pedigree-fhir-ig/CodeSystem/PedigreeRelationships
+Alias: $PedigreeRelationshipsCodeSystem = http://purl.org/ga4gh/pedigree-fhir-ig/CodeSystem/PedigreeRelationships
+Alias: $UnbornExtension = http://purl.org/ga4gh/pedigree-fhir-ig/StructureDefinition/patient-unborn
+

--- a/input/fsh/Example-Simpsons.fsh
+++ b/input/fsh/Example-Simpsons.fsh
@@ -2,7 +2,7 @@ Instance: Bart
 InstanceOf: PedigreeIndividual
 Title: "Bart"
 Description: "Bart is the proband and consultand."
-* extension[0].url = "http://ga4gh-cp.github.io/pedigree-fhir-ig/StructureDefinition/patient-unborn"
+* extension[0].url = $UnbornExtension
 * extension[0].valueBoolean = false
 * gender = #male
 * identifier.system = "urn:fdc:sprinfieldlab.net:2021:id/patient"
@@ -13,7 +13,7 @@ Instance: Homer
 InstanceOf: PedigreeIndividual
 Title: "Homer"
 Description: "Homer is Bart's father and Marge's husband."
-* extension[0].url = "http://ga4gh-cp.github.io/pedigree-fhir-ig/StructureDefinition/patient-unborn"
+* extension[0].url = $UnbornExtension
 * extension[0].valueBoolean = false
 * gender = #male
 * identifier.system = "urn:fdc:sprinfieldlab.net:2021:id/patient"
@@ -24,7 +24,7 @@ Instance: Marge
 InstanceOf: PedigreeIndividual
 Title: "Marge"
 Description: "Marge is Bart's mother and Homer's wife."
-* extension[0].url = "http://ga4gh-cp.github.io/pedigree-fhir-ig/StructureDefinition/patient-unborn"
+* extension[0].url = $UnbornExtension
 * extension[0].valueBoolean = false
 * gender = #female
 * identifier.system = "urn:fdc:sprinfieldlab.net:2021:id/patient"
@@ -35,7 +35,7 @@ Instance: Abe
 InstanceOf: PedigreeIndividual
 Title: "Abe"
 Description: "Abe is Homer's father."
-* extension[0].url = "http://ga4gh-cp.github.io/pedigree-fhir-ig/StructureDefinition/patient-unborn"
+* extension[0].url = $UnbornExtension
 * extension[0].valueBoolean = false
 * gender = #female
 * identifier.system = "urn:fdc:sprinfieldlab.net:2021:id/patient"
@@ -49,7 +49,7 @@ Description: "The relationship between Bart and his mother."
 * status = #completed
 * identifier.system = "urn:fdc:sprinfieldlab.net:2021:id/relationship"
 * identifier.value = "bart_marge"
-* relationship = $PedigreeRelationships#REL:003
+* relationship = $PedigreeRelationshipsCodeSystem#REL:003
 * patient = Reference(Bart)
 * extension[0].url = $PatientRecordExtension
 * extension[0].valueReference = Reference(Marge)
@@ -61,7 +61,7 @@ Description: "The relationship between Bart and his father."
 * status = #completed
 * identifier.system = "urn:fdc:sprinfieldlab.net:2021:id/relationship"
 * identifier.value = "bart_homer"
-* relationship = $PedigreeRelationships#REL:003
+* relationship = $PedigreeRelationshipsCodeSystem#REL:003
 * patient = Reference(Bart)
 * extension[0].url = $PatientRecordExtension
 * extension[0].valueReference = Reference(Homer)
@@ -73,7 +73,7 @@ Description: "The relationship between Marge and her husband."
 * status = #completed
 * identifier.system = "urn:fdc:sprinfieldlab.net:2021:id/relationship"
 * identifier.value = "marge_homer"
-* relationship = $PedigreeRelationships#REL:026
+* relationship = $PedigreeRelationshipsCodeSystem#REL:026
 * patient = Reference(Marge)
 * extension[0].url = $PatientRecordExtension
 * extension[0].valueReference = Reference(Homer)
@@ -85,7 +85,7 @@ Description: "The relationship between Homer and his father."
 * status = #completed
 * identifier.system = "urn:fdc:sprinfieldlab.net:2021:id/relationship"
 * identifier.value = "homer_abe"
-* relationship = $PedigreeRelationships#REL:003
+* relationship = $PedigreeRelationshipsCodeSystem#REL:003
 * patient = Reference(Homer)
 * extension[0].url = $PatientRecordExtension
 * extension[0].valueReference = Reference(Abe)

--- a/input/fsh/Example-Trio.fsh
+++ b/input/fsh/Example-Trio.fsh
@@ -77,7 +77,7 @@ Description: "The relationship between the proband and her father."
 * status = #completed
 * identifier.system = "urn:fdc:labtec.genovic.org.au:2018:id/relationship"
 * identifier.value = "proband_father"
-* relationship = $PedigreeRelationships#REL:003
+* relationship = $PedigreeRelationshipsCodeSystem#REL:003
 * patient = Reference(Proband)
 * extension[0].url = $PatientRecordExtension
 * extension[0].valueReference = Reference(Father)
@@ -89,7 +89,7 @@ Description: "The relationship between the proband and her mother."
 * status = #completed
 * identifier.system = "urn:fdc:labtec.genovic.org.au:2018:id/relationship"
 * identifier.value = "proband_mother"
-* relationship = $PedigreeRelationships#REL:003
+* relationship = $PedigreeRelationshipsCodeSystem#REL:003
 * patient = Reference(Proband)
 * extension[0].url = $PatientRecordExtension
 * extension[0].valueReference = Reference(Mother)

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,6 +1,6 @@
 ### Scope
 
-Family health history is an important aspect in both genomic research and patient care. The Global Alliance for Genomics and Health is working on a pedigree standard that will allow sharing family history data in a way that is accurate, easy to analyse and transferable between systems. The group has created a [conceptual model](https://github.com/ga4gh-cp/pedigree/blob/2021-01/model.md) and a [minimal data set document](https://docs.google.com/document/d/1UAtSLBEQ_7ePRLvDPRpoFpiXnl6VQEJXL2eQByEmfGY/) that have been used as the basis for this FHIR implementation guide.
+Family health history is an important aspect in both genomic research and patient care. The Global Alliance for Genomics and Health is working on a pedigree standard that will allow sharing family history data in a way that is accurate, easy to analyse and transferable between systems. The group has created a [conceptual model](https://github.com/GA4GH-Pedigree-Standard/pedigree/blob/master/model.md) and a [minimal data set document](https://docs.google.com/document/d/1UAtSLBEQ_7ePRLvDPRpoFpiXnl6VQEJXL2eQByEmfGY/) that have been used as the basis for this FHIR implementation guide.
 
 ### Understanding FHIR (Prerequisite)
 

--- a/input/vocabulary/CodeSystem-PedigreeRelationships.json
+++ b/input/vocabulary/CodeSystem-PedigreeRelationships.json
@@ -5,7 +5,7 @@
     "status" : "generated",
     "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This code system http://ga4gh-cp.github.io/pedigree-fhir-ig/CodeSystem/PedigreeRelationships defines the following codes:</p><table class=\"codes\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td style=\"white-space:nowrap\">REL:001</td><td>Relative</td></tr><tr><td style=\"white-space:nowrap\">REL:002</td><td>Biological relative</td></tr><tr><td style=\"white-space:nowrap\">REL:003</td><td>Biological parent</td></tr><tr><td style=\"white-space:nowrap\">REL:004</td><td>Sperm / ovum donor</td></tr><tr><td style=\"white-space:nowrap\">REL:005</td><td>Gestational carrier</td></tr><tr><td style=\"white-space:nowrap\">REL:006</td><td>Surrogate ovum donor</td></tr><tr><td style=\"white-space:nowrap\">REL:007</td><td>Biological sibling</td></tr><tr><td style=\"white-space:nowrap\">REL:008</td><td>Full sibling</td></tr><tr><td style=\"white-space:nowrap\">REL:009</td><td>Twin</td></tr><tr><td style=\"white-space:nowrap\">REL:010</td><td>Monozygotic twin</td></tr><tr><td style=\"white-space:nowrap\">REL:011</td><td>Polyzygotic twin</td></tr><tr><td style=\"white-space:nowrap\">REL:012</td><td>Half-sibling</td></tr><tr><td style=\"white-space:nowrap\">REL:013</td><td>Uncle</td></tr><tr><td style=\"white-space:nowrap\">REL:014</td><td>Cousin</td></tr><tr><td style=\"white-space:nowrap\">REL:015</td><td>Maternal cousin</td></tr><tr><td style=\"white-space:nowrap\">REL:016</td><td>Paternal cousin</td></tr><tr><td style=\"white-space:nowrap\">REL:017</td><td>Grandparent</td></tr><tr><td style=\"white-space:nowrap\">REL:018</td><td>Great-grandparent</td></tr><tr><td style=\"white-space:nowrap\">REL:019</td><td>Social / legal relative</td></tr><tr><td style=\"white-space:nowrap\">REL:020</td><td>Parent figure</td></tr><tr><td style=\"white-space:nowrap\">REL:021</td><td>Foster parent</td></tr><tr><td style=\"white-space:nowrap\">REL:022</td><td>Adoptive parent</td></tr><tr><td style=\"white-space:nowrap\">REL:023</td><td>Step-parent</td></tr><tr><td style=\"white-space:nowrap\">REL:024</td><td>Sibling figure</td></tr><tr><td style=\"white-space:nowrap\">REL:025</td><td>Step-sibling</td></tr><tr><td style=\"white-space:nowrap\">REL:026</td><td>Significant other</td></tr></table></div>"
   },
-  "url": "http://ga4gh-cp.github.io/pedigree-fhir-ig/CodeSystem/PedigreeRelationships",
+  "url": "http://purl.org/ga4gh/pedigree-fhir-ig/CodeSystem/PedigreeRelationships",
   "version": "0.1.0",
   "name": "PedigreeRelationships",
   "title": "Pedigree Relationships",
@@ -15,7 +15,7 @@
   "publisher": "CSIRO",
   "description": "Code system for pedigree realtionship types.",
   "caseSensitive": true,
-  "valueSet": "http://ga4gh-cp.github.io/pedigree-fhir-ig/CodeSystem/PedigreeRelationships?vs",
+  "valueSet": "http://purl.org/ga4gh/pedigree-fhir-ig/CodeSystem/PedigreeRelationships?vs",
   "hierarchyMeaning": "is-a",
   "compositional": false,
   "versionNeeded": false,

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -3,7 +3,7 @@
 # │  supported properties, see: https://fshschool.org/sushi/configuration/                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 id: ga4gh.fhir.pedigree
-canonical: http://ga4gh-cp.github.io/pedigree-fhir-ig
+canonical: http://purl.org/ga4gh/pedigree-fhir-ig
 name: GA4GHPedigreeIG
 title: "GA4GH Pedigree FHIR Implementation Guide"
 description: "FHIR implementation guide for the Global Alliance for Genomics and Health Pedigree standard."


### PR DESCRIPTION
@liberaliscomputing, the link in the README to the documentation was broken when the repository was moved to new Github workspace. I updated the canonical URL of the IG to be a permanent URL so it can be redirected if this happens again.